### PR TITLE
Fix Interlining Issues

### DIFF
--- a/conf/base/catalog/odx.yml
+++ b/conf/base/catalog/odx.yml
@@ -3,7 +3,6 @@
 # Documentation for this file format can be found in "The Data Catalog"
 # Link: https://kedro.readthedocs.io/en/stable/05_data/01_data_catalog.html
 
-
 #trimet sourced files
 hop_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
@@ -40,7 +39,7 @@ stop_times_prepared_spark_df:
   file_format: "parquet"
   save_args:
     mode: "overwrite"
-    partitionBy: ["SERVICE_DATE","HOUR"]
+    partitionBy: ["SERVICE_DATE", "HOUR"]
 
 inferred_rider_events_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
@@ -61,171 +60,123 @@ impossible_journeys_spark_df:
     mode: "overwrite"
     partitionBy: "SERVICE_DATE"
 
-
 #gtfs files
 agency_gtfs_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*agency.txt"
+    pathGlobFilter: "*agency.parquet"
     basePath: "data/01_raw/gtfs"
 
 calendar_gtfs_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*calendar.txt"
+    pathGlobFilter: "*calendar.parquet"
     basePath: "data/01_raw/gtfs"
 
 calendar_gtfs_dates_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: false
-    schema: "service_id string, date integer, exception_type integer"
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*calendar_dates.txt"
+    pathGlobFilter: "*calendar_dates.parquet"
     basePath: "data/01_raw/gtfs"
 
 fare_gtfs_attributes_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*fare_attributes.txt"
+    pathGlobFilter: "*fare_attributes.parquet"
     basePath: "data/01_raw/gtfs"
 
 fare_gtfs_rules_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*fare_rules.txt"
+    pathGlobFilter: "*fare_rules.parquet"
     basePath: "data/01_raw/gtfs"
 
 feed_gtfs_info_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*feed_info.txt"
+    pathGlobFilter: "*feed_info.parquet"
     basePath: "data/01_raw/gtfs"
 
 linked_gtfs_datasets_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*linked_datasets.txt"
+    pathGlobFilter: "*linked_datasets.parquet"
     basePath: "data/01_raw/gtfs"
 
 route_gtfs_directions_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*route_directions.txt"
+    pathGlobFilter: "*route_directions.parquet"
     basePath: "data/01_raw/gtfs"
 
 routes_gtfs_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*routes.txt"
+    pathGlobFilter: "*routes.parquet"
     basePath: "data/01_raw/gtfs"
 
 shapes_gtfs_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*shapes.txt"
+    pathGlobFilter: "*shapes.parquet"
     basePath: "data/01_raw/gtfs"
 
 stop_features_gtfs_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*stop_features.txt"
+    pathGlobFilter: "*stop_features.parquet"
     basePath: "data/01_raw/gtfs"
 
 stop_times_gtfs_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*stop_times.txt"
+    pathGlobFilter: "*stop_times.parquet"
     basePath: "data/01_raw/gtfs"
 
 stops_gtfs_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*stops.txt"
+    pathGlobFilter: "*stops.parquet"
     basePath: "data/01_raw/gtfs"
 
 transfers_gtfs_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: true
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*transfers.txt"
+    pathGlobFilter: "*transfers.parquet"
     basePath: "data/01_raw/gtfs"
 
 trips_gtfs_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
   filepath: "data/01_raw/gtfs"
-  file_format: "csv"
-  load_args:
-    header: true
-    inferSchema: false
-    schema: "route_id string, service_id integer, trip_id integer, trip_headsign string, trip_short_name string, direction_id integer, block_id integer, shape_id integer, trip_type integer, wheelchair_accessible integer, bikes_allowed integer"
+  file_format: "parquet"
   generic_load_args:
-    pathGlobFilter: "*trips.txt"
+    pathGlobFilter: "*trips.parquet"
     basePath: "data/01_raw/gtfs"

--- a/conf/base/catalog/odx.yml
+++ b/conf/base/catalog/odx.yml
@@ -17,7 +17,7 @@ hop_spark_df_prepared_spark_df:
   file_format: "parquet"
   save_args:
     mode: "overwrite"
-    partitionBy: "service_date"
+    partitionBy: "SERVICE_DATE"
 
 stop_times_avl_raw_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"
@@ -31,7 +31,7 @@ interlining_trip_ids_prepared_spark_df:
   filepath: "data/02_intermediate/stop_times_avl/interlining"
   save_args:
     mode: "overwrite"
-    partitionBy: "service_date"
+    partitionBy: "SERVICE_DATE"
 
 stop_times_prepared_spark_df:
   type: "kedro.extras.datasets.spark.SparkDataSet"

--- a/src/odx/SparkContext.py
+++ b/src/odx/SparkContext.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/odx/SparkContext.py
+++ b/src/odx/SparkContext.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from kedro.framework.context import KedroContext
 from pyspark import SparkConf
 from pyspark.sql import SparkSession
-
-from kedro.framework.context import KedroContext
 
 
 class SparkContext(KedroContext):

--- a/src/odx/__init__.py
+++ b/src/odx/__init__.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/odx/__main__.py
+++ b/src/odx/__main__.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/odx/pipeline_registry.py
+++ b/src/odx/pipeline_registry.py
@@ -28,9 +28,11 @@
 
 """Project pipelines."""
 from typing import Dict
+
 from kedro.pipeline import Pipeline, pipeline
-from .pipelines.odx.prepare import pipeline as prepare_odx
+
 from .pipelines.odx.infer import pipeline as infer_odx
+from .pipelines.odx.prepare import pipeline as prepare_odx
 
 
 def register_pipelines() -> Dict[str, Pipeline]:

--- a/src/odx/pipelines/__init__.py
+++ b/src/odx/pipelines/__init__.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/odx/pipelines/odx/infer/impossible_conditions_and_descriptions.py
+++ b/src/odx/pipelines/odx/infer/impossible_conditions_and_descriptions.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyspark.sql import functions as F
 from typing import List
+
+from pyspark.sql import functions as F
+
 from .utils import haversine_meters
 
 
@@ -30,21 +32,8 @@ def get_impossible_conditions_and_descriptions(
     """
     return [
         (
-            (F.col("ALIGHTING_ARRIVE_DATETIME") == F.col("DATETIME_NEXT")),
+            (F.col("ALIGHTING_STOP_ARRIVE_DATETIME") == F.col("DATETIME_NEXT")),
             "ALIGHTING DATETIME EQUAL TO NEXT BOARDING DATETIME",
-        ),
-        (
-            (
-                (
-                    F.col("INTERLINING_STOP_LAT").isNull()
-                    & (~F.col("INTERLINING_STOP_ID").isNull())
-                )
-                | (
-                    F.col("INTERLINING_STOP_LAT_NEXT").isNull()
-                    & (~F.col("INTERLINING_STOP_ID_NEXT").isNull())
-                )
-            ),
-            "INTERLINING STOP DOESN'T HAVE A LOCATION",
         ),
         (
             (F.col("STOP_ID") == F.col("STOP_ID_NEXT")),
@@ -53,7 +42,7 @@ def get_impossible_conditions_and_descriptions(
         (
             (
                 (
-                    F.col("ALIGHTING_ARRIVE_DATETIME").cast("long")
+                    F.col("ALIGHTING_STOP_ARRIVE_DATETIME").cast("long")
                     + F.col("MINIMUM_REQUIRED_TRANSFER_TIME_SECONDS")
                 )
                 > (F.col("DATETIME_NEXT").cast("long") + 300)
@@ -63,7 +52,7 @@ def get_impossible_conditions_and_descriptions(
         (
             (
                 (
-                    F.col("ALIGHTING_ARRIVE_DATETIME").cast("long")
+                    F.col("ALIGHTING_STOP_ARRIVE_DATETIME").cast("long")
                     <= F.col("DATETIME").cast("long")
                 )
             ),
@@ -72,7 +61,7 @@ def get_impossible_conditions_and_descriptions(
         (
             (
                 (
-                    F.col("ALIGHTING_ARRIVE_DATETIME").cast("long")
+                    F.col("ALIGHTING_STOP_ARRIVE_DATETIME").cast("long")
                     > F.col("DATETIME_NEXT").cast("long")
                 )
             ),
@@ -147,7 +136,7 @@ def get_impossible_conditions_and_descriptions(
             & F.col("MEAN_BOARDING_INTERVAL_SECONDS").isNull(),
             "NO BOARDING INTERVAL BOARDING TAP",
         ),
-        (F.col("STOP_LINE_ID_OLD").isNull(), "OLD LINE ID IS NULL"),
+        (F.col("BOARDING_STOP_LINE_ID_OLD").isNull() , "OLD LINE ID IS NULL"),
         (
             (
                 haversine_meters(
@@ -157,7 +146,7 @@ def get_impossible_conditions_and_descriptions(
                     F.col("ALIGHTING_STOP_LON"),
                 )
                 / (
-                    F.col("ALIGHTING_ARRIVE_DATETIME").cast("long")
+                    F.col("ALIGHTING_STOP_ARRIVE_DATETIME").cast("long")
                     - F.col("ARRIVE_DATETIME").cast("long")
                 )
             )

--- a/src/odx/pipelines/odx/infer/nodes.py
+++ b/src/odx/pipelines/odx/infer/nodes.py
@@ -1490,7 +1490,7 @@ def remove_unexpected_journey_event_sequences(
     )
     return successful_journeys_spark_df.filter(
         F.col("UNEXPECTED_EVENT_PAIR") == 0
-    ).drop("NEXT_EVENT", "UNEXPECTED_EVENT_PAIR")
+    ).drop("NEXT_EVENT", "UNEXPECTED_EVENT_PAIR", "EVENT_PAIR")
 
 
 def validate_successful_journeys(successful_journeys_spark_df: SparkDF) -> SparkDF:

--- a/src/odx/pipelines/odx/infer/utils.py
+++ b/src/odx/pipelines/odx/infer/utils.py
@@ -1,4 +1,6 @@
-from pyspark.sql import functions as F,Column
+from pyspark.sql import Column
+from pyspark.sql import functions as F
+
 
 def haversine_meters(
     lat_1_col: Column, lon_1_col: Column, lat_2_col: Column, lon_2_col: Column

--- a/src/odx/pipelines/odx/prepare/pipeline.py
+++ b/src/odx/pipelines/odx/prepare/pipeline.py
@@ -15,30 +15,31 @@
 """Pipeline for preparing data for HOP ODX inference
 """
 from kedro.pipeline import Pipeline, node
+
 from ..infer.nodes import get_year_months
 from .nodes import (
-    validate_no_nulls_on_columns,
-    fill_transaction_ticket_description_nulls_with_unknown,
-    map_line_ids,
-    create_datetime_column,
-    remove_duplicate_taps,
-    create_date_column,
-    identify_unwanted_operators,
-    remove_unknown_stops,
     add_source_column,
-    merge_stop_locations_onto_stop_times,
-    get_relevant_stop_times,
-    merge_trip_information_onto_avl_stop_times,
-    convert_string_route_ids_to_integers,
-    build_stop_times_from_stops_avl,
-    get_trip_id_start_end_stop_ids_and_times,
     build_blocks,
-    create_interlining_trips,
-    get_arrival_datetime_hour,
-    repartition_by,
-    coalesce_stop_times,
     build_stop_headways,
+    build_stop_times_from_stops_avl,
+    coalesce_stop_times,
+    convert_string_route_ids_to_integers,
+    create_date_column,
+    create_datetime_column,
+    create_interlining_trips,
+    fill_transaction_ticket_description_nulls_with_unknown,
+    get_arrival_datetime_hour,
+    get_relevant_stop_times,
+    get_trip_id_start_end_stop_ids_and_times,
+    identify_unwanted_operators,
     map_column_name_to_upper_case,
+    map_line_ids,
+    merge_stop_locations_onto_stop_times,
+    merge_trip_information_onto_avl_stop_times,
+    remove_duplicate_taps,
+    remove_unknown_stops,
+    repartition_by,
+    validate_no_nulls_on_columns,
 )
 
 

--- a/src/odx/pipelines/odx/prepare/utils.py
+++ b/src/odx/pipelines/odx/prepare/utils.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,9 +14,9 @@
 
 """Utility functions for the prepare nodes.
 """
-from pyspark.sql import DataFrame as SparkDF
-from pyspark.sql.types import StringType, IntegerType
 import pyspark.sql.functions as F
+from pyspark.sql import DataFrame as SparkDF
+from pyspark.sql.types import IntegerType, StringType
 
 
 def get_arrival_and_departure_datetimes(stops_times_spark_df: SparkDF) -> SparkDF:

--- a/src/odx/settings.py
+++ b/src/odx/settings.py
@@ -27,6 +27,10 @@
 # limitations under the License.
 
 """Project settings."""
+from pathlib import Path
+
+from kedro_viz.integrations.kedro.sqlite_store import SQLiteStore
+
 from odx.SparkContext import SparkContext
 
 # Instantiate and list your project hooks here
@@ -35,8 +39,6 @@ from odx.SparkContext import SparkContext
 # List the installed plugins for which to disable auto-registry
 # DISABLE_HOOKS_FOR_PLUGINS = ("kedro-viz",)
 
-from kedro_viz.integrations.kedro.sqlite_store import SQLiteStore
-from pathlib import Path
 
 SESSION_STORE_CLASS = SQLiteStore
 SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data")}

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/tests/pipelines/__init__.py
+++ b/src/tests/pipelines/__init__.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
The most recent version of the code showed a regression in the inference of interlining journeys. The issues came from logical errors in the insertion of interlining events after the journey inference had been completed. This PR fixes these issues by:
- Wholesale replacing component interlining trips with synthesized trips that represent the entire journey of the vehicle, with interlining stops/trips marked as such.
- Including a check for expected event type pairs and removing journeys that don't conform (approximately 3% of journeys). The primary source of unexpected event type pairs (e.g. a boarding followed by another boarding) seems to stem from riders who tap a while after they've boarded a bus. Producing adequate inferences in these cases would require a change in the overall inference approach.
- Setting the boarding time to the boarding trip arrival time rather than the observed tap time.
- Adjusting the impossible journeys conditions to reflect fixes/changes.
- Including a metric calculating the number of journeys including an interlining event.